### PR TITLE
rabbitmq: config nodename and give permissions to rabbitmq user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update
 RUN apt-get -y install --no-install-recommends rabbitmq-server
 RUN apt-get -y autoremove && apt-get -y clean
 ENV RABBITMQ_NODENAME=rabbit@localhost
+ARG DEBUG=0
+RUN if [ "${DEBUG}" -gt 0 ]; then rabbitmq-plugins enable rabbitmq_management; fi;
 # hadolint ignore=DL3001
 RUN service rabbitmq-server start
 COPY start.sh /start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update
 # hadolint ignore=DL3008
 RUN apt-get -y install --no-install-recommends rabbitmq-server
 RUN apt-get -y autoremove && apt-get -y clean
+ENV RABBITMQ_NODENAME=rabbit@localhost
 # hadolint ignore=DL3001
 RUN service rabbitmq-server start
 COPY start.sh /start.sh

--- a/start.sh
+++ b/start.sh
@@ -11,4 +11,5 @@ cat > /etc/rabbitmq/rabbitmq.config <<EOF
 	{rabbit, [{default_user, <<"$1">>},{default_pass, <<"$2">>},{tcp_listeners, [{"0.0.0.0", 5672}]}]}
 ].
 EOF
+chown rabbitmq:rabbitmq /var/lib/rabbitmq/mnesia
 rabbitmq-server


### PR DESCRIPTION
closes https://github.com/reanahub/reana/issues/500

**Test working of new config**
 
1. rabbitmq user has proper permissions
 - Message broker pod should not give the `permission denied` error.
 - Check in the UI in admin panel if `test` has admin privileges.
