### PR TITLE
docker: switched to rabbitmq base image, added message delay plugin 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Version 0.8.0 (UNRELEASED)
+---------------------------
+
+- Changes base image to the official RabbitMQ Docker image.
+- Adds RabbitMQ message delay plugin.
+- Adds RabbitMQ management UI exposed on port 31672 in the cluster debug mode.
+
 Version 0.7.1 (2021-02-03)
 --------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-FROM ubuntu:16.04
-# hadolint ignore=DL3009
-RUN apt-get update
-# hadolint ignore=DL3008
-RUN apt-get -y install --no-install-recommends rabbitmq-server
+FROM rabbitmq:3.8-management
+
+# hadolint ignore=DL3009, DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
 RUN apt-get -y autoremove && apt-get -y clean
+
 ENV RABBITMQ_NODENAME=rabbit@localhost
 ARG DEBUG=0
-RUN if [ "${DEBUG}" -gt 0 ]; then rabbitmq-plugins enable rabbitmq_management; fi;
-# hadolint ignore=DL3001
-RUN service rabbitmq-server start
+
+RUN curl -L "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.8.9/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez" > "$RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez"
+RUN chown rabbitmq:rabbitmq "$RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez"
+
+RUN rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
+RUN rabbitmq-plugins enable --offline rabbitmq_consistent_hash_exchange
+RUN if [ "${DEBUG}" -lt 1 ]; then rabbitmq-plugins disable --offline rabbitmq_management; fi
+
 COPY start.sh /start.sh
 RUN chmod 755 ./start.sh
-EXPOSE 5672
-EXPOSE 15672
 CMD ["/start.sh", "test", "1234"]


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/118

- Switched to official RabbitMQ base image: `rabbitmq:3.8.9-management`
- Install and enable `rabbitmq_delayed_message_exchange` (inspiration from this [Dockerfile](https://github.com/heidiks/rabbitmq-delayed-message-exchange/blob/master/versions/3.8.9-management/Dockerfile))
- Disable `rabbitmq_management` on production mode (enabled by default)

Testing:
```console
reana-dev docker-build -c reana-message-broker -b DEBUG=1 --no-cache
reana-dev kind-load-docker-image -c reana-message-broker
redeploy the cluster
kubectl exec -it reana-message-broker-5874b75cdd-tnqmv  rabbitmq-plugins list <-- to see the list of enabled plugins
```
