### PR TITLE
docker: removed message delay plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,6 @@ Version 0.8.0 (UNRELEASED)
 ---------------------------
 
 - Changes base image to the official RabbitMQ Docker image.
-- Adds RabbitMQ message delay plugin.
 - Adds RabbitMQ management UI exposed on port 31672 in the cluster debug mode.
 
 Version 0.7.1 (2021-02-03)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,12 @@
 FROM rabbitmq:3.8-management
 
 # hadolint ignore=DL3009, DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+RUN apt-get update
 RUN apt-get -y autoremove && apt-get -y clean
 
 ENV RABBITMQ_NODENAME=rabbit@localhost
 ARG DEBUG=0
 
-RUN curl -L "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.8.9/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez" > "$RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez"
-RUN chown rabbitmq:rabbitmq "$RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez"
-
-RUN rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
-RUN rabbitmq-plugins enable --offline rabbitmq_consistent_hash_exchange
 RUN if [ "${DEBUG}" -lt 1 ]; then rabbitmq-plugins disable --offline rabbitmq_management; fi
 
 COPY start.sh /start.sh


### PR DESCRIPTION
Please note that `rm -rf /var/reana/rabbitmq` might be necessary before loading the new container.

Testing:
```console
reana-dev docker-build -c reana-message-broker -b DEBUG=1 --no-cache
reana-dev kind-load-docker-image -c reana-message-broker
redeploy the cluster
kubectl exec -it reana-message-broker-5874b75cdd-tnqmv  rabbitmq-plugins list <-- to see the list of enabled plugins
```
Also after running some demos one can inspect [RabbitMQ UI](http://localhost:31672/#/exchanges) to see that `workflow-submission` exchange is no longer there, since the default one is used now.