### PR TITLE
docker: limit maximum number of open file descriptors

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
-- `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
 - `Harri Hirvonsalo <https://orcid.org/0000-0002-5503-510X>`_
+- `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
+- `Marco Donadoni <https://orcid.org/0000-0003-2922-5505>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.1 (UNRELEASED)
+--------------------------
+
+- Fixes high memory usage of rabbitmq by limiting the maximum number of open file descriptors.
+
 Version 0.9.0 (2023-01-19)
 --------------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -56,7 +56,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "reana"
-copyright = "2017-2020, info@reana.io"
+copyright = "2017-2023, info@reana.io"
 author = "info@reana.io"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/reana_message_broker/version.py
+++ b/reana_message_broker/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0"
+__version__ = "0.9.1a1"

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2021 CERN.
+# Copyright (C) 2017, 2018, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,4 +12,6 @@ cat > /etc/rabbitmq/rabbitmq.config <<EOF
 ].
 EOF
 chown rabbitmq:rabbitmq /var/lib/rabbitmq/mnesia
+# Limit maximum number of open file descriptors to avoid high memory usage
+ulimit -n 1048576
 rabbitmq-server


### PR DESCRIPTION
This commit limits the maximum number of open file descriptors in order
to fix high memory usage of rabbitmq. The number of maximum open file
descriptors is set to the same value as reanahub/reana#703.
