### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,9 +2,15 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "80...100"
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        base: auto
+        target: auto
+        threshold: 2%
 
 parsers:
   gcov:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-FROM rabbitmq:3.8-management
+FROM docker.io/library/rabbitmq:3.8-management
 
 ENV RABBITMQ_NODENAME=rabbit@localhost
 ARG DEBUG=0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -41,7 +41,7 @@ check_pytest () {
 }
 
 check_dockerfile () {
-    docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 }
 
 check_docker_build () {


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.