### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -37,7 +37,11 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    if [ -n "${PYTESTARG-}" ]; then
+        pytest "$PYTESTARG"
+    else
+        python setup.py test
+    fi
 }
 
 check_dockerfile () {


### PR DESCRIPTION
Allows execution of selected pytests via PYTESTARG environment variable. Example:

```
$ PYTESTARG=tests/test_version.py ./run-tests.sh --check-pytest
```

Closes reanahub/reana#755.