### PR TITLE
 fix(start): handle signals for graceful shutdown

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -14,4 +14,4 @@ EOF
 chown rabbitmq:rabbitmq /var/lib/rabbitmq/mnesia
 # Limit maximum number of open file descriptors to avoid high memory usage
 ulimit -n 1048576
-rabbitmq-server
+exec rabbitmq-server


### PR DESCRIPTION
Use `exec` to execute RabbitMQ's server, so that the server process can
receive signals such as `SIGTERM`.

Closes reanahub/reana-job-controller#347
