### PR TITLE
deprecations setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,7 +55,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_dockerfile () {

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -18,23 +18,21 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "check-manifest>=0.25",
-    "coverage>=4.0",
-    "pydocstyle>=1.0.0",
-    "pytest-cache>=1.0",
-    "pytest-cov>=1.8.0",
-    "pytest-pep8>=1.0.6",
-    "pytest>=3.8.0",
-]
-
 extras_require = {
     "docs": [
         "myst-parser",
         "Sphinx>=1.4.4",
         "sphinx-rtd-theme>=0.1.9",
     ],
-    "tests": tests_require,
+    "tests": [
+        "check-manifest>=0.25",
+        "coverage>=4.0",
+        "pydocstyle>=1.0.0",
+        "pytest-cache>=1.0",
+        "pytest-cov>=1.8.0",
+        "pytest-pep8>=1.0.6",
+        "pytest>=3.8.0",
+    ],
 }
 
 extras_require["all"] = []
@@ -64,7 +62,6 @@ setup(
     packages=["reana_message_broker"],
     zip_safe=False,
     extras_require=extras_require,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 packages = find_packages()
 
 
@@ -68,7 +64,6 @@ setup(
     packages=["reana_message_broker"],
     zip_safe=False,
     extras_require=extras_require,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#71)**
- **build(python): remove deprecated `pytest-runner` (#71)**
- **build(python): use optional deps instead of `tests_require` (#71)**
- **build(python): add minimal `pyproject.toml` (#71)**

Closes https://github.com/reanahub/reana/issues/814