### PR TITLE
chore(master): backfill missing copyright years

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2024 CERN.
+# Copyright (C) 2020, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021, 2024 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021, 2023 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2018 CERN.
+# Copyright (C) 2018, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/reana_message_broker/version.py
+++ b/reana_message_broker/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021, 2023, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018 CERN.
+# Copyright (C) 2017, 2018, 2021, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,7 +30,6 @@ extras_require = {
         "pydocstyle>=1.0.0",
         "pytest-cache>=1.0",
         "pytest-cov>=1.8.0",
-        "pytest-pep8>=1.0.6",
         "pytest>=3.8.0",
     ],
 }

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2021, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2021, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
Update source file copyright headers and top-level LICENSE files
to include the years in which each file was modified according to
git history, without following renames.

Closes reanahub/reana#973